### PR TITLE
fix: get_invoice_status

### DIFF
--- a/views_api.py
+++ b/views_api.py
@@ -177,7 +177,7 @@ async def lndhub_getuserinvoices(
         exclude_uncheckable=True,
     ):
         await invoice.set_pending(
-            (await funding_source.invoice_status(invoice.checking_id)).pending
+            (await funding_source.get_invoice_status(invoice.checking_id)).pending
         )
 
     return [


### PR DESCRIPTION
I believe this is where a mistake was made during the #26 renaming. 

`AttributeError: 'LndRestWallet' object has no attribute 'invoice_status'`